### PR TITLE
Add daily check-in module

### DIFF
--- a/lib/checkin/checkin_data.dart
+++ b/lib/checkin/checkin_data.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+class CheckinData {
+  final TimeOfDay wakeUpTime;
+  final int rounds;
+  final bool exercised;
+  final bool read;
+  final int urgeIntensity;
+  final bool didFall;
+
+  CheckinData({
+    required this.wakeUpTime,
+    required this.rounds,
+    required this.exercised,
+    required this.read,
+    required this.urgeIntensity,
+    required this.didFall,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'wakeUpHour': wakeUpTime.hour,
+        'wakeUpMinute': wakeUpTime.minute,
+        'rounds': rounds,
+        'exercised': exercised,
+        'read': read,
+        'urgeIntensity': urgeIntensity,
+        'didFall': didFall,
+      };
+
+  factory CheckinData.fromJson(Map<String, dynamic> json) {
+    return CheckinData(
+      wakeUpTime: TimeOfDay(
+        hour: json['wakeUpHour'] as int,
+        minute: json['wakeUpMinute'] as int,
+      ),
+      rounds: json['rounds'] as int,
+      exercised: json['exercised'] as bool,
+      read: json['read'] as bool,
+      urgeIntensity: json['urgeIntensity'] as int,
+      didFall: json['didFall'] as bool,
+    );
+  }
+}

--- a/lib/checkin/checkin_page.dart
+++ b/lib/checkin/checkin_page.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+
+import 'checkin_data.dart';
+import 'checkin_service.dart';
+
+class CheckinPage extends StatefulWidget {
+  const CheckinPage({super.key});
+
+  @override
+  State<CheckinPage> createState() => _CheckinPageState();
+}
+
+class _CheckinPageState extends State<CheckinPage> {
+  final _service = CheckinService();
+
+  TimeOfDay _wakeUpTime = const TimeOfDay(hour: 5, minute: 0);
+  final _roundsController = TextEditingController();
+  bool _exercised = false;
+  bool _read = false;
+  double _urgeIntensity = 1;
+  bool _didFall = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadToday();
+  }
+
+  Future<void> _loadToday() async {
+    final data = await _service.getCheckin(DateTime.now());
+    if (data != null) {
+      setState(() {
+        _wakeUpTime = data.wakeUpTime;
+        _roundsController.text = data.rounds.toString();
+        _exercised = data.exercised;
+        _read = data.read;
+        _urgeIntensity = data.urgeIntensity.toDouble();
+        _didFall = data.didFall;
+      });
+    }
+  }
+
+  Future<void> _save() async {
+    final data = CheckinData(
+      wakeUpTime: _wakeUpTime,
+      rounds: int.tryParse(_roundsController.text) ?? 0,
+      exercised: _exercised,
+      read: _read,
+      urgeIntensity: _urgeIntensity.toInt(),
+      didFall: _didFall,
+    );
+    await _service.saveCheckin(DateTime.now(), data);
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Check-in saved')),);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Daily Check-in')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          ListTile(
+            title: const Text('Wake-up time'),
+            subtitle: Text(_wakeUpTime.format(context)),
+            onTap: () async {
+              final time = await showTimePicker(
+                context: context,
+                initialTime: _wakeUpTime,
+              );
+              if (time != null) {
+                setState(() => _wakeUpTime = time);
+              }
+            },
+          ),
+          TextField(
+            controller: _roundsController,
+            decoration: const InputDecoration(labelText: 'Rounds'),
+            keyboardType: TextInputType.number,
+          ),
+          SwitchListTile(
+            title: const Text('Exercised'),
+            value: _exercised,
+            onChanged: (v) => setState(() => _exercised = v),
+          ),
+          SwitchListTile(
+            title: const Text('Read scripture'),
+            value: _read,
+            onChanged: (v) => setState(() => _read = v),
+          ),
+          ListTile(
+            title: const Text('Urge intensity'),
+            subtitle: Slider(
+              value: _urgeIntensity,
+              min: 1,
+              max: 10,
+              divisions: 9,
+              label: _urgeIntensity.round().toString(),
+              onChanged: (v) => setState(() => _urgeIntensity = v),
+            ),
+          ),
+          SwitchListTile(
+            title: const Text('Fell from practice'),
+            value: _didFall,
+            onChanged: (v) => setState(() => _didFall = v),
+          ),
+          const SizedBox(height: 20),
+          ElevatedButton(
+            onPressed: _save,
+            child: const Text('Save'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/checkin/checkin_service.dart
+++ b/lib/checkin/checkin_service.dart
@@ -1,0 +1,28 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'checkin_data.dart';
+
+class CheckinService {
+  static const _prefix = 'checkin_';
+
+  Future<void> saveCheckin(DateTime date, CheckinData data) async {
+    final prefs = await SharedPreferences.getInstance();
+    final key = _keyForDate(date);
+    await prefs.setString(key, jsonEncode(data.toJson()));
+  }
+
+  Future<CheckinData?> getCheckin(DateTime date) async {
+    final prefs = await SharedPreferences.getInstance();
+    final key = _keyForDate(date);
+    final raw = prefs.getString(key);
+    if (raw == null) return null;
+    return CheckinData.fromJson(jsonDecode(raw) as Map<String, dynamic>);
+  }
+
+  String _keyForDate(DateTime date) {
+    final d = DateTime(date.year, date.month, date.day);
+    return '${_prefix}${d.toIso8601String()}';
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'checkin/checkin_page.dart';
 
 void main() {
   runApp(const MyApp());
@@ -15,7 +16,7 @@ class MyApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+      home: const CheckinPage(),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^1.0.2
+  shared_preferences: ^2.2.0
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## Summary
- add CheckinData model and CheckinService for persistence
- create CheckinPage with form inputs for daily stats
- hook CheckinPage into `main.dart`
- add `shared_preferences` dependency

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877550bf044832da1fdcfadd57ea28d