### PR TITLE
Add dashboard with fl_chart metrics

### DIFF
--- a/lib/checkin/checkin_service.dart
+++ b/lib/checkin/checkin_service.dart
@@ -21,6 +21,25 @@ class CheckinService {
     return CheckinData.fromJson(jsonDecode(raw) as Map<String, dynamic>);
   }
 
+  Future<Map<DateTime, CheckinData>> getAllCheckins() async {
+    final prefs = await SharedPreferences.getInstance();
+    final result = <DateTime, CheckinData>{};
+    for (final key in prefs.getKeys()) {
+      if (!key.startsWith(_prefix)) continue;
+      final raw = prefs.getString(key);
+      if (raw == null) continue;
+      final dateString = key.substring(_prefix.length);
+      try {
+        final date = DateTime.parse(dateString);
+        result[DateTime(date.year, date.month, date.day)] =
+            CheckinData.fromJson(jsonDecode(raw) as Map<String, dynamic>);
+      } catch (_) {
+        continue;
+      }
+    }
+    return result;
+  }
+
   String _keyForDate(DateTime date) {
     final d = DateTime(date.year, date.month, date.day);
     return '${_prefix}${d.toIso8601String()}';

--- a/lib/dashboard/dashboard_page.dart
+++ b/lib/dashboard/dashboard_page.dart
@@ -1,0 +1,154 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+
+import '../checkin/checkin_data.dart';
+import '../checkin/checkin_service.dart';
+import 'victory_quote_service.dart';
+
+class DashboardPage extends StatefulWidget {
+  const DashboardPage({super.key});
+
+  @override
+  State<DashboardPage> createState() => _DashboardPageState();
+}
+
+class _DashboardPageState extends State<DashboardPage> {
+  final _checkinService = CheckinService();
+  final _quoteService = VictoryQuoteService();
+
+  Map<DateTime, CheckinData> _data = {};
+  String _quote = '';
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final data = await _checkinService.getAllCheckins();
+    final quote = await _quoteService.getQuote();
+    setState(() {
+      _data = data;
+      _quote = quote;
+    });
+  }
+
+  int get _streak {
+    final dates = _data.keys.toList()..sort();
+    int streak = 0;
+    DateTime? last;
+    for (final date in dates.reversed) {
+      if (last != null && last.difference(date).inDays > 1) break;
+      final info = _data[date]!;
+      if (info.didFall) break;
+      streak++;
+      last = date;
+    }
+    return streak;
+  }
+
+  List<FlSpot> get _roundSpots {
+    final dates = _data.keys.toList()..sort();
+    final List<FlSpot> spots = [];
+    for (var i = 0; i < dates.length; i++) {
+      final d = dates[i];
+      final info = _data[d]!;
+      spots.add(FlSpot(i.toDouble(), info.rounds.toDouble()));
+    }
+    return spots;
+  }
+
+  List<FlSpot> get _urgeSpots {
+    final dates = _data.keys.toList()..sort();
+    final List<FlSpot> spots = [];
+    for (var i = 0; i < dates.length; i++) {
+      final d = dates[i];
+      final info = _data[d]!;
+      spots.add(FlSpot(i.toDouble(), info.urgeIntensity.toDouble()));
+    }
+    return spots;
+  }
+
+  Future<void> _editQuote() async {
+    final controller = TextEditingController(text: _quote);
+    final result = await showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Edit victory quote'),
+        content: TextField(
+          controller: controller,
+          decoration: const InputDecoration(labelText: 'Quote'),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Cancel'),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.of(context).pop(controller.text),
+            child: const Text('Save'),
+          ),
+        ],
+      ),
+    );
+    if (result != null && result.isNotEmpty) {
+      await _quoteService.setQuote(result);
+      setState(() => _quote = result);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Dashboard')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Card(
+            child: ListTile(
+              title: Text(_quote),
+              trailing: IconButton(
+                icon: const Icon(Icons.edit),
+                onPressed: _editQuote,
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          Text('Current streak: $_streak days',
+              style: Theme.of(context).textTheme.titleMedium),
+          const SizedBox(height: 16),
+          AspectRatio(
+            aspectRatio: 1.7,
+            child: LineChart(
+              LineChartData(
+                lineBarsData: [
+                  LineChartBarData(spots: _roundSpots, color: Colors.blue),
+                ],
+                titlesData: FlTitlesData(show: false),
+                gridData: FlGridData(show: false),
+              ),
+            ),
+          ),
+          const SizedBox(height: 8),
+          const Text('Total rounds over time'),
+          const SizedBox(height: 16),
+          AspectRatio(
+            aspectRatio: 1.7,
+            child: LineChart(
+              LineChartData(
+                lineBarsData: [
+                  LineChartBarData(spots: _urgeSpots, color: Colors.red),
+                ],
+                titlesData: FlTitlesData(show: false),
+                gridData: FlGridData(show: false),
+              ),
+            ),
+          ),
+          const SizedBox(height: 8),
+          const Text('Urge intensity over time'),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/dashboard/victory_quote_service.dart
+++ b/lib/dashboard/victory_quote_service.dart
@@ -1,0 +1,25 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class VictoryQuoteService {
+  static const _key = 'victory_quote';
+  static const _defaultQuotes = [
+    'Victory belongs to the most persevering.',
+    'Every day is a chance to rise higher.',
+    'Steady practice leads to certain success.',
+  ];
+
+  Future<String> getQuote() async {
+    final prefs = await SharedPreferences.getInstance();
+    final custom = prefs.getString(_key);
+    if (custom != null && custom.isNotEmpty) {
+      return custom;
+    }
+    final index = DateTime.now().day % _defaultQuotes.length;
+    return _defaultQuotes[index];
+  }
+
+  Future<void> setQuote(String quote) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_key, quote);
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'checkin/checkin_page.dart';
+import 'dashboard/dashboard_page.dart';
 
 void main() {
   runApp(const MyApp());
@@ -16,48 +17,34 @@ class MyApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
-      home: const CheckinPage(),
+      home: const HomePage(),
     );
   }
 }
 
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  final String title;
+class HomePage extends StatefulWidget {
+  const HomePage({super.key});
 
   @override
-  State<MyHomePage> createState() => _MyHomePageState();
+  State<HomePage> createState() => _HomePageState();
 }
 
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
+class _HomePageState extends State<HomePage> {
+  int _index = 0;
 
-  void _incrementCounter() {
-    setState(() {
-      _counter++;
-    });
-  }
+  final _pages = const [CheckinPage(), DashboardPage()];
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: Text(widget.title),
-      ),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text('$_counter', style: Theme.of(context).textTheme.headlineMedium),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
+      body: _pages[_index],
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _index,
+        onTap: (i) => setState(() => _index = i),
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.edit), label: 'Check-in'),
+          BottomNavigationBarItem(icon: Icon(Icons.show_chart), label: 'Stats'),
+        ],
       ),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ dependencies:
     sdk: flutter
   cupertino_icons: ^1.0.2
   shared_preferences: ^2.2.0
+  fl_chart: ^0.65.0
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## Summary
- add `fl_chart` dependency
- provide `getAllCheckins` in `CheckinService`
- implement `VictoryQuoteService`
- create `DashboardPage` with charts and editable quote
- add bottom navigation between check-in and dashboard

## Testing
- `dart format -o none --set-exit-if-changed lib` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687755d3f278832d9361620c77ab6cd2