### PR TITLE
Add journaling screen

### DIFF
--- a/lib/journal/journal_entry.dart
+++ b/lib/journal/journal_entry.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+class JournalEntry {
+  final DateTime timestamp;
+  final String helped;
+  final String triggered;
+
+  JournalEntry({
+    required this.timestamp,
+    required this.helped,
+    required this.triggered,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'timestamp': timestamp.toIso8601String(),
+        'helped': helped,
+        'triggered': triggered,
+      };
+
+  factory JournalEntry.fromJson(Map<String, dynamic> json) {
+    return JournalEntry(
+      timestamp: DateTime.parse(json['timestamp'] as String),
+      helped: json['helped'] as String,
+      triggered: json['triggered'] as String,
+    );
+  }
+}

--- a/lib/journal/journal_page.dart
+++ b/lib/journal/journal_page.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+
+import 'journal_entry.dart';
+import 'journal_service.dart';
+
+class JournalPage extends StatefulWidget {
+  const JournalPage({super.key});
+
+  @override
+  State<JournalPage> createState() => _JournalPageState();
+}
+
+class _JournalPageState extends State<JournalPage> {
+  final _service = JournalService();
+
+  final _helpedController = TextEditingController();
+  final _triggerController = TextEditingController();
+
+  List<JournalEntry> _entries = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final entries = await _service.getEntries();
+    setState(() => _entries = entries.reversed.toList());
+  }
+
+  Future<void> _save() async {
+    final helped = _helpedController.text.trim();
+    final triggered = _triggerController.text.trim();
+    if (helped.isEmpty && triggered.isEmpty) return;
+    final entry = JournalEntry(
+      timestamp: DateTime.now(),
+      helped: helped,
+      triggered: triggered,
+    );
+    await _service.addEntry(entry);
+    _helpedController.clear();
+    _triggerController.clear();
+    await _load();
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Journal entry saved')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Journal')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          TextField(
+            controller: _helpedController,
+            decoration: const InputDecoration(
+              labelText: 'What helped you stay strong?',
+            ),
+            minLines: 2,
+            maxLines: 3,
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _triggerController,
+            decoration: const InputDecoration(
+              labelText: 'What triggered weakness?',
+            ),
+            minLines: 2,
+            maxLines: 3,
+          ),
+          const SizedBox(height: 12),
+          ElevatedButton(
+            onPressed: _save,
+            child: const Text('Save'),
+          ),
+          const SizedBox(height: 24),
+          ..._entries.map((e) => Card(
+                child: ListTile(
+                  title: Text(
+                    '${e.timestamp.year}-${e.timestamp.month.toString().padLeft(2, '0')}-${e.timestamp.day.toString().padLeft(2, '0')}',
+                  ),
+                  subtitle: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      if (e.helped.isNotEmpty)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 4.0),
+                          child: Text('Helped: ${e.helped}'),
+                        ),
+                      if (e.triggered.isNotEmpty)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 4.0),
+                          child: Text('Triggered: ${e.triggered}'),
+                        ),
+                    ],
+                  ),
+                ),
+              )),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/journal/journal_service.dart
+++ b/lib/journal/journal_service.dart
@@ -1,0 +1,28 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'journal_entry.dart';
+
+class JournalService {
+  static const _key = 'journal_entries';
+
+  Future<List<JournalEntry>> getEntries() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_key);
+    if (raw == null) return [];
+    final List<dynamic> list = jsonDecode(raw) as List<dynamic>;
+    return list
+        .cast<Map<String, dynamic>>()
+        .map(JournalEntry.fromJson)
+        .toList();
+  }
+
+  Future<void> addEntry(JournalEntry entry) async {
+    final prefs = await SharedPreferences.getInstance();
+    final entries = await getEntries();
+    entries.add(entry);
+    final raw = jsonEncode(entries.map((e) => e.toJson()).toList());
+    await prefs.setString(_key, raw);
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'checkin/checkin_page.dart';
 import 'dashboard/dashboard_page.dart';
+import 'journal/journal_page.dart';
 
 void main() {
   runApp(const MyApp());
@@ -32,7 +33,7 @@ class HomePage extends StatefulWidget {
 class _HomePageState extends State<HomePage> {
   int _index = 0;
 
-  final _pages = const [CheckinPage(), DashboardPage()];
+  final _pages = const [CheckinPage(), DashboardPage(), JournalPage()];
 
   @override
   Widget build(BuildContext context) {
@@ -44,6 +45,7 @@ class _HomePageState extends State<HomePage> {
         items: const [
           BottomNavigationBarItem(icon: Icon(Icons.edit), label: 'Check-in'),
           BottomNavigationBarItem(icon: Icon(Icons.show_chart), label: 'Stats'),
+          BottomNavigationBarItem(icon: Icon(Icons.book), label: 'Journal'),
         ],
       ),
     );


### PR DESCRIPTION
## Summary
- add a new journal feature
- allow saving entries about what helped and what triggered weakness
- list past entries
- hook journal page into the bottom navigation

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68775849b8f8832da1568d6d1910d603