### PR TITLE
Add global theme with custom colors and font

### DIFF
--- a/lib/dashboard/dashboard_page.dart
+++ b/lib/dashboard/dashboard_page.dart
@@ -123,7 +123,10 @@ class _DashboardPageState extends State<DashboardPage> {
             child: LineChart(
               LineChartData(
                 lineBarsData: [
-                  LineChartBarData(spots: _roundSpots, color: Colors.blue),
+                  LineChartBarData(
+                    spots: _roundSpots,
+                    color: Theme.of(context).colorScheme.tertiary,
+                  ),
                 ],
                 titlesData: FlTitlesData(show: false),
                 gridData: FlGridData(show: false),
@@ -138,7 +141,10 @@ class _DashboardPageState extends State<DashboardPage> {
             child: LineChart(
               LineChartData(
                 lineBarsData: [
-                  LineChartBarData(spots: _urgeSpots, color: Colors.red),
+                  LineChartBarData(
+                    spots: _urgeSpots,
+                    color: Theme.of(context).colorScheme.error,
+                  ),
                 ],
                 titlesData: FlTitlesData(show: false),
                 gridData: FlGridData(show: false),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'checkin/checkin_page.dart';
 import 'dashboard/dashboard_page.dart';
 import 'journal/journal_page.dart';
+import 'theme.dart';
 
 void main() {
   runApp(const MyApp());
@@ -14,10 +15,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Flutter Demo',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-        useMaterial3: true,
-      ),
+      theme: AppTheme.theme,
       home: const HomePage(),
     );
   }

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+class AppTheme {
+  static const Color saffron = Color(0xFFFF9933);
+  static const Color tulasiGreen = Color(0xFF009F30);
+  static const Color gopiBlue = Color(0xFF0F52BA);
+
+  static final ThemeData theme = ThemeData(
+    useMaterial3: true,
+    colorScheme: ColorScheme.light(
+      primary: saffron,
+      secondary: tulasiGreen,
+      tertiary: gopiBlue,
+    ),
+    textTheme: GoogleFonts.hindTextTheme(ThemeData.light().textTheme),
+  );
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   cupertino_icons: ^1.0.2
   shared_preferences: ^2.2.0
   fl_chart: ^0.65.0
+  google_fonts: ^6.1.0
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## Summary
- define a shared `ThemeData` in `AppTheme`
- apply the theme in `MaterialApp`
- update dashboard chart colors to use the theme
- add google_fonts dependency for the Hind font

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687760f16c5c832d9c5ed4a4856622cb