### PR TITLE
Add widget tests and CI workflow

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -1,0 +1,19 @@
+name: Flutter CI
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - name: Install dependencies
+        run: flutter pub get
+      - name: Analyze
+        run: flutter analyze
+      - name: Test
+        run: flutter test

--- a/test/checkin_page_test.dart
+++ b/test/checkin_page_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:nitya_dasa/checkin/checkin_page.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('Check-in page saves data', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: CheckinPage()));
+
+    expect(find.text('Daily Check-in'), findsOneWidget);
+
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Save'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Check-in saved'), findsOneWidget);
+  });
+}

--- a/test/dashboard_page_test.dart
+++ b/test/dashboard_page_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:nitya_dasa/dashboard/dashboard_page.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('Dashboard loads with default data', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: DashboardPage()));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Dashboard'), findsOneWidget);
+    expect(find.text('Current streak: 0 days'), findsOneWidget);
+    expect(find.text('Total rounds over time'), findsOneWidget);
+    expect(find.text('Urge intensity over time'), findsOneWidget);
+  });
+}

--- a/test/journal_page_test.dart
+++ b/test/journal_page_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:nitya_dasa/journal/journal_page.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('Journal page saves entry', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: JournalPage()));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+        find.byWidgetPredicate((w) =>
+            w is TextField &&
+            w.decoration?.labelText == 'What helped you stay strong?'),
+        'Chanting');
+    await tester.enterText(
+        find.byWidgetPredicate((w) =>
+            w is TextField &&
+            w.decoration?.labelText == 'What triggered weakness?'),
+        'TV');
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Save'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Journal entry saved'), findsOneWidget);
+  });
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -4,16 +4,12 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:nitya_dasa/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
+  testWidgets('Home page shows navigation items', (tester) async {
     await tester.pumpWidget(const MyApp());
 
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.byType(BottomNavigationBar), findsOneWidget);
+    expect(find.byIcon(Icons.edit), findsOneWidget);
+    expect(find.byIcon(Icons.show_chart), findsOneWidget);
+    expect(find.byIcon(Icons.book), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- add GitHub Actions CI for flutter analyze and flutter test
- add widget tests for CheckinPage, DashboardPage and JournalPage
- replace default widget test with bottom navigation check

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_687761ae4fcc832d89441e2e7f046f2a