### PR TITLE
Add daily notifications with customizable times

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ Key planned features include:
 
 For a more detailed overview, see [docs/features.md](docs/features.md).
 
+## Notifications
+
+Daily reminders help keep you on track. The app uses
+`flutter_local_notifications` to schedule a morning and evening reminder.
+By default these fire at **7:00 AM** and **7:00 PM**. You can adjust these
+times from the **Settings** page inside the app.
+
 ## Installation
 
 1. Ensure you have the [Flutter SDK](https://flutter.dev/) installed.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,9 +2,21 @@ import 'package:flutter/material.dart';
 import 'checkin/checkin_page.dart';
 import 'dashboard/dashboard_page.dart';
 import 'journal/journal_page.dart';
+import 'settings/settings_page.dart';
+import 'settings/settings_service.dart';
+import 'notifications/notification_service.dart';
 import 'theme.dart';
 
-void main() {
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  final settings = SettingsService();
+  final morning = await settings.getMorningTime();
+  final evening = await settings.getEveningTime();
+  await NotificationService.instance.init();
+  await NotificationService.instance.scheduleDailyReminders(
+    morning: Time(morning.hour, morning.minute),
+    evening: Time(evening.hour, evening.minute),
+  );
   runApp(const MyApp());
 }
 
@@ -31,7 +43,12 @@ class HomePage extends StatefulWidget {
 class _HomePageState extends State<HomePage> {
   int _index = 0;
 
-  final _pages = const [CheckinPage(), DashboardPage(), JournalPage()];
+  final _pages = const [
+    CheckinPage(),
+    DashboardPage(),
+    JournalPage(),
+    SettingsPage(),
+  ];
 
   @override
   Widget build(BuildContext context) {
@@ -44,6 +61,7 @@ class _HomePageState extends State<HomePage> {
           BottomNavigationBarItem(icon: Icon(Icons.edit), label: 'Check-in'),
           BottomNavigationBarItem(icon: Icon(Icons.show_chart), label: 'Stats'),
           BottomNavigationBarItem(icon: Icon(Icons.book), label: 'Journal'),
+          BottomNavigationBarItem(icon: Icon(Icons.settings), label: 'Settings'),
         ],
       ),
     );

--- a/lib/notifications/notification_service.dart
+++ b/lib/notifications/notification_service.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:timezone/timezone.dart' as tz;
+import 'package:timezone/data/latest.dart' as tz;
+
+class NotificationService {
+  NotificationService._internal();
+  static final NotificationService instance = NotificationService._internal();
+
+  final FlutterLocalNotificationsPlugin _plugin =
+      FlutterLocalNotificationsPlugin();
+
+  Future<void> init() async {
+    const android = AndroidInitializationSettings('@mipmap/ic_launcher');
+    const ios = DarwinInitializationSettings();
+    const settings = InitializationSettings(android: android, iOS: ios);
+    await _plugin.initialize(settings);
+    tz.initializeTimeZones();
+  }
+
+  Future<void> scheduleDailyReminders({
+    required Time morning,
+    required Time evening,
+  }) async {
+    await _plugin.cancelAll();
+
+    const androidDetails = AndroidNotificationDetails(
+      'daily_reminders',
+      'Daily Reminders',
+      channelDescription: 'Morning and evening reminder notifications',
+      importance: Importance.defaultImportance,
+    );
+    const iosDetails = DarwinNotificationDetails();
+    const details = NotificationDetails(android: androidDetails, iOS: iosDetails);
+
+    await _plugin.zonedSchedule(
+      0,
+      'Morning Reminder',
+      'Start your day with devotion',
+      _nextInstance(morning),
+      details,
+      androidAllowWhileIdle: true,
+      uiLocalNotificationDateInterpretation:
+          UILocalNotificationDateInterpretation.wallClockTime,
+      matchDateTimeComponents: DateTimeComponents.time,
+    );
+
+    await _plugin.zonedSchedule(
+      1,
+      'Evening Reminder',
+      'Reflect on your day',
+      _nextInstance(evening),
+      details,
+      androidAllowWhileIdle: true,
+      uiLocalNotificationDateInterpretation:
+          UILocalNotificationDateInterpretation.wallClockTime,
+      matchDateTimeComponents: DateTimeComponents.time,
+    );
+  }
+
+  tz.TZDateTime _nextInstance(Time time) {
+    final now = tz.TZDateTime.now(tz.local);
+    var scheduled = tz.TZDateTime(tz.local, now.year, now.month, now.day,
+        time.hour, time.minute);
+    if (scheduled.isBefore(now)) {
+      scheduled = scheduled.add(const Duration(days: 1));
+    }
+    return scheduled;
+  }
+}

--- a/lib/settings/settings_page.dart
+++ b/lib/settings/settings_page.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+
+import '../notifications/notification_service.dart';
+import 'settings_service.dart';
+
+class SettingsPage extends StatefulWidget {
+  const SettingsPage({super.key});
+
+  @override
+  State<SettingsPage> createState() => _SettingsPageState();
+}
+
+class _SettingsPageState extends State<SettingsPage> {
+  final _service = SettingsService();
+  TimeOfDay _morning = const TimeOfDay(hour: 7, minute: 0);
+  TimeOfDay _evening = const TimeOfDay(hour: 19, minute: 0);
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final morning = await _service.getMorningTime();
+    final evening = await _service.getEveningTime();
+    setState(() {
+      _morning = morning;
+      _evening = evening;
+    });
+  }
+
+  Future<void> _save() async {
+    await _service.setMorningTime(_morning);
+    await _service.setEveningTime(_evening);
+    await NotificationService.instance.scheduleDailyReminders(
+      morning: Time(_morning.hour, _morning.minute),
+      evening: Time(_evening.hour, _evening.minute),
+    );
+    if (mounted) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('Settings saved')));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Settings')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          ListTile(
+            title: const Text('Morning reminder time'),
+            subtitle: Text(_morning.format(context)),
+            onTap: () async {
+              final time = await showTimePicker(
+                context: context,
+                initialTime: _morning,
+              );
+              if (time != null) {
+                setState(() => _morning = time);
+              }
+            },
+          ),
+          ListTile(
+            title: const Text('Evening reminder time'),
+            subtitle: Text(_evening.format(context)),
+            onTap: () async {
+              final time = await showTimePicker(
+                context: context,
+                initialTime: _evening,
+              );
+              if (time != null) {
+                setState(() => _evening = time);
+              }
+            },
+          ),
+          const SizedBox(height: 20),
+          ElevatedButton(
+            onPressed: _save,
+            child: const Text('Save'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/settings/settings_service.dart
+++ b/lib/settings/settings_service.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class SettingsService {
+  static const _morningKey = 'morning_time';
+  static const _eveningKey = 'evening_time';
+
+  Future<TimeOfDay> getMorningTime() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_morningKey);
+    if (raw == null) return const TimeOfDay(hour: 7, minute: 0);
+    final parts = raw.split(':');
+    return TimeOfDay(
+      hour: int.parse(parts[0]),
+      minute: int.parse(parts[1]),
+    );
+  }
+
+  Future<TimeOfDay> getEveningTime() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_eveningKey);
+    if (raw == null) return const TimeOfDay(hour: 19, minute: 0);
+    final parts = raw.split(':');
+    return TimeOfDay(
+      hour: int.parse(parts[0]),
+      minute: int.parse(parts[1]),
+    );
+  }
+
+  Future<void> setMorningTime(TimeOfDay time) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_morningKey, '${time.hour}:${time.minute}');
+  }
+
+  Future<void> setEveningTime(TimeOfDay time) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_eveningKey, '${time.hour}:${time.minute}');
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,8 @@ dependencies:
   shared_preferences: ^2.2.0
   fl_chart: ^0.65.0
   google_fonts: ^6.1.0
+  flutter_local_notifications: ^16.1.0
+  timezone: ^0.9.2
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## Summary
- integrate flutter_local_notifications and timezone packages
- schedule morning and evening reminders in NotificationService
- add Settings page to configure reminder times
- wire settings and notifications into app startup and navigation
- document notification behaviour in README

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68776461e4b8832d828a6deedd28c426