### PR TITLE
Switch NotificationService to TimeOfDay

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,8 +14,8 @@ Future<void> main() async {
   final evening = await settings.getEveningTime();
   await NotificationService.instance.init();
   await NotificationService.instance.scheduleDailyReminders(
-    morning: Time(morning.hour, morning.minute),
-    evening: Time(evening.hour, evening.minute),
+    morning: morning,
+    evening: evening,
   );
   runApp(const MyApp());
 }

--- a/lib/notifications/notification_service.dart
+++ b/lib/notifications/notification_service.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:timezone/timezone.dart' as tz;
 import 'package:timezone/data/latest.dart' as tz;
@@ -18,8 +19,8 @@ class NotificationService {
   }
 
   Future<void> scheduleDailyReminders({
-    required Time morning,
-    required Time evening,
+    required TimeOfDay morning,
+    required TimeOfDay evening,
   }) async {
     await _plugin.cancelAll();
 
@@ -57,7 +58,7 @@ class NotificationService {
     );
   }
 
-  tz.TZDateTime _nextInstance(Time time) {
+  tz.TZDateTime _nextInstance(TimeOfDay time) {
     final now = tz.TZDateTime.now(tz.local);
     var scheduled = tz.TZDateTime(tz.local, now.year, now.month, now.day,
         time.hour, time.minute);

--- a/lib/settings/settings_page.dart
+++ b/lib/settings/settings_page.dart
@@ -34,8 +34,8 @@ class _SettingsPageState extends State<SettingsPage> {
     await _service.setMorningTime(_morning);
     await _service.setEveningTime(_evening);
     await NotificationService.instance.scheduleDailyReminders(
-      morning: Time(_morning.hour, _morning.minute),
-      evening: Time(_evening.hour, _evening.minute),
+      morning: _morning,
+      evening: _evening,
     );
     if (mounted) {
       ScaffoldMessenger.of(context)


### PR DESCRIPTION
## Summary
- accept `TimeOfDay` in `NotificationService.scheduleDailyReminders`
- update `main.dart` and `settings_page.dart` to pass `TimeOfDay` values

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68776cf4e0bc832da3135bd75b2a0597