### PR TITLE
Enable core library desugaring for Android

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -13,6 +13,7 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
+        coreLibraryDesugaringEnabled = true
     }
 
     kotlinOptions {
@@ -41,4 +42,8 @@ android {
 
 flutter {
     source = "../.."
+}
+
+dependencies {
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
 }


### PR DESCRIPTION
## Summary
- enable core library desugaring in Android app module
- add dependency on `desugar_jdk_libs`

## Testing
- `gradle -p android help --quiet` *(fails: `/workspace/nitya-dasa/android/local.properties (No such file or directory)`)*

------
https://chatgpt.com/codex/tasks/task_e_68777053cd58832dbce9da9f21154372