### PR TITLE
Update CONTRIBUTING testing instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Thank you for your interest in contributing to **Nitya Dāsa**! This document ex
 
 ## Running Tests
 
-This project currently has no automated tests. As tests are added, you can run them with:
+Run all Flutter widget tests with:
 
 ```bash
 flutter test


### PR DESCRIPTION
## Summary
- remove obsolete note about missing tests and instruct to run widget tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687770e33ab8832daa808b0a1d608f48