### PR TITLE
Pin flutter_local_notifications to 17.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   shared_preferences: ^2.2.0
   fl_chart: ^0.65.0
   google_fonts: ^6.1.0
-  flutter_local_notifications: ^16.1.0
+  flutter_local_notifications: 17.0.0
   timezone: ^0.9.2
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- pin `flutter_local_notifications` to version `17.0.0`

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68778547a10c832d81da2f0d264575fc