### PR TITLE
Add settings page test

### DIFF
--- a/test/settings_page_test.dart
+++ b/test/settings_page_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/services.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:nitya_dasa/settings/settings_page.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const MethodChannel channel = MethodChannel('dexterous.com/flutter/local_notifications');
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    channel.setMockMethodCallHandler((MethodCall methodCall) async {
+      return null;
+    });
+  });
+
+  tearDown(() {
+    channel.setMockMethodCallHandler(null);
+  });
+
+  testWidgets('Save button shows snack bar', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: SettingsPage()));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Save'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Settings saved'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add test for SettingsPage save button

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877982752cc832d8a86084bbdd3ce32