### PR TITLE
Add running tests info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ times from the **Settings** page inside the app.
    flutter run
    ```
 
+## Running Tests
+
+Widget tests can be executed using:
+
+```bash
+flutter test
+```
+
+For more details, see [CONTRIBUTING.md](CONTRIBUTING.md).
+
 ## Usage Notes
 
 At this stage the project is in early development. After cloning and installing dependencies, you can run the default Flutter app as a starting point. As new features are implemented, this README will be updated with additional instructions.


### PR DESCRIPTION
## Summary
- document how to run widget tests using `flutter test`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68779c886658832daa4ebc7f814505de