### PR TITLE
Add exact alarm permission

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <application
         android:label="nitya_dasa"
         android:name="${applicationName}"


### PR DESCRIPTION
## Summary
- allow exact alarms on Android by adding `SCHEDULE_EXACT_ALARM` permission

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877a4f2d134832d8357b1423b94bda3