### PR TITLE
Ensure widget mount checks before setState

### DIFF
--- a/lib/checkin/checkin_page.dart
+++ b/lib/checkin/checkin_page.dart
@@ -28,6 +28,7 @@ class _CheckinPageState extends State<CheckinPage> {
 
   Future<void> _loadToday() async {
     final data = await _service.getCheckin(DateTime.now());
+    if (!mounted) return;
     if (data != null) {
       setState(() {
         _wakeUpTime = data.wakeUpTime;

--- a/lib/dashboard/dashboard_page.dart
+++ b/lib/dashboard/dashboard_page.dart
@@ -28,6 +28,7 @@ class _DashboardPageState extends State<DashboardPage> {
   Future<void> _load() async {
     final data = await _checkinService.getAllCheckins();
     final quote = await _quoteService.getQuote();
+    if (!mounted) return;
     setState(() {
       _data = data;
       _quote = quote;

--- a/lib/journal/journal_page.dart
+++ b/lib/journal/journal_page.dart
@@ -26,6 +26,7 @@ class _JournalPageState extends State<JournalPage> {
 
   Future<void> _load() async {
     final entries = await _service.getEntries();
+    if (!mounted) return;
     setState(() => _entries = entries.reversed.toList());
   }
 

--- a/lib/settings/settings_page.dart
+++ b/lib/settings/settings_page.dart
@@ -24,6 +24,7 @@ class _SettingsPageState extends State<SettingsPage> {
   Future<void> _load() async {
     final morning = await _service.getMorningTime();
     final evening = await _service.getEveningTime();
+    if (!mounted) return;
     setState(() {
       _morning = morning;
       _evening = evening;


### PR DESCRIPTION
## Summary
- guard against unmounted widgets in journal, settings, check-in, and dashboard pages

## Testing
- `flutter format .` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877a68feb50832da1b883b5c3ae19dc