### PR TITLE
Add Android 12 alarm note

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Daily reminders help keep you on track. The app uses
 `flutter_local_notifications` to schedule a morning and evening reminder.
 By default these fire at **7:00 AM** and **7:00 PM**. You can adjust these
 times from the **Settings** page inside the app.
+Note: On Android 12+ the app needs the `SCHEDULE_EXACT_ALARM` permission and you may have to allow exact alarms in system settings.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- add note about exact alarm permission in Notifications section

## Testing
- `flutter test` *(fails: `bash: command not found: flutter`)*

------
https://chatgpt.com/codex/tasks/task_e_6877a8575444832d8f72ff0365e05d33