### PR TITLE
Fix method name for scheduling exact alarms

### DIFF
--- a/lib/notifications/notification_service.dart
+++ b/lib/notifications/notification_service.dart
@@ -32,7 +32,7 @@ class NotificationService {
       final androidImpl = _plugin.resolvePlatformSpecificImplementation<
           AndroidFlutterLocalNotificationsPlugin>();
       try {
-        final allowed = await androidImpl?.requestPermissionToScheduleExactAlarms();
+        final allowed = await androidImpl?.requestExactAlarmsPermission();
         if (allowed == false) {
           debugPrint('Exact alarm permission not granted');
           return;


### PR DESCRIPTION
## Summary
- fix method name to request exact alarm permission

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877adc5b808832d813ef7bf218f02f7