### PR TITLE
Add note about pubspec.lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Note: On Android 12+ the app needs the `SCHEDULE_EXACT_ALARM` permission and you
    ```bash
    flutter pub get
    ```
+   The generated `pubspec.lock` file is checked into version control so
+   that all developers work with the same dependency versions.
 5. Run the application on an emulator or connected device:
    ```bash
    flutter run


### PR DESCRIPTION
## Summary
- note that `pubspec.lock` is checked into version control

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877ae362954832d84f533e8d8a6feda