### PR TITLE
Remove const from EmergencyPage constructor

### DIFF
--- a/lib/emergency/emergency_page.dart
+++ b/lib/emergency/emergency_page.dart
@@ -4,7 +4,7 @@ import 'package:just_audio/just_audio.dart';
 import 'vow_service.dart';
 
 class EmergencyPage extends StatefulWidget {
-  const EmergencyPage({super.key, AudioPlayer? player}) : _player = player ?? AudioPlayer();
+  EmergencyPage({super.key, AudioPlayer? player}) : _player = player ?? AudioPlayer();
 
   final AudioPlayer _player;
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -44,12 +44,12 @@ class HomePage extends StatefulWidget {
 class _HomePageState extends State<HomePage> {
   int _index = 0;
 
-  final _pages = const [
-    CheckinPage(),
-    DashboardPage(),
-    JournalPage(),
+  final _pages = [
+    const CheckinPage(),
+    const DashboardPage(),
+    const JournalPage(),
     EmergencyPage(),
-    SettingsPage(),
+    const SettingsPage(),
   ];
 
   @override


### PR DESCRIPTION
## Summary
- update EmergencyPage constructor to be non-const
- update `_pages` list in `main.dart` to instantiate `EmergencyPage()` non-const

## Testing
- `flutter format .` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877b9158c98832db30d76213038ee6c