### PR TITLE
Fix playback button

### DIFF
--- a/lib/emergency/emergency_page.dart
+++ b/lib/emergency/emergency_page.dart
@@ -47,7 +47,7 @@ class _EmergencyPageState extends State<EmergencyPage> {
           Text(_vow, style: Theme.of(context).textTheme.titleMedium),
           const SizedBox(height: 16),
           ElevatedButton(
-            onPressed: widget._player.play,
+            onPressed: () => widget._player.play(),
             child: const Text('Play Mantra'),
           ),
         ],


### PR DESCRIPTION
## Summary
- ensure the emergency page button calls `play()` via a closure

## Testing
- `flutter format .` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877b98c8f18832db9b01b5deec19629