### PR TITLE
Implement hearing option with duration tracking

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -4,8 +4,10 @@ This document outlines planned capabilities for the **Nitya Dāsa** mobile appli
 
 ## Main Functionality
 
-- **Daily check-in** to track sadhana and personal goals
-- **Progress dashboard** with charts of japa counts and other metrics
+- **Daily check-in** to track sadhana and personal goals including
+  minutes spent exercising, reading, and hearing scripture
+- **Progress dashboard** with charts of japa counts, urge intensity,
+  and time spent exercising, reading, and hearing
 - **Daily journal** for notes and reflections
 - **Emergency mode** for quick access to important practices and resources
 - **Notifications** and reminders to help stay consistent

--- a/lib/checkin/checkin_data.dart
+++ b/lib/checkin/checkin_data.dart
@@ -2,16 +2,18 @@ import 'package:flutter/material.dart';
 class CheckinData {
   final TimeOfDay wakeUpTime;
   final int rounds;
-  final bool exercised;
-  final bool read;
+  final int exerciseMinutes;
+  final int readingMinutes;
+  final int hearingMinutes;
   final int urgeIntensity;
   final bool didFall;
 
   CheckinData({
     required this.wakeUpTime,
     required this.rounds,
-    required this.exercised,
-    required this.read,
+    required this.exerciseMinutes,
+    required this.readingMinutes,
+    required this.hearingMinutes,
     required this.urgeIntensity,
     required this.didFall,
   });
@@ -20,8 +22,9 @@ class CheckinData {
         'wakeUpHour': wakeUpTime.hour,
         'wakeUpMinute': wakeUpTime.minute,
         'rounds': rounds,
-        'exercised': exercised,
-        'read': read,
+        'exerciseMinutes': exerciseMinutes,
+        'readingMinutes': readingMinutes,
+        'hearingMinutes': hearingMinutes,
         'urgeIntensity': urgeIntensity,
         'didFall': didFall,
       };
@@ -33,8 +36,9 @@ class CheckinData {
         minute: json['wakeUpMinute'] as int,
       ),
       rounds: json['rounds'] as int,
-      exercised: json['exercised'] as bool,
-      read: json['read'] as bool,
+      exerciseMinutes: (json['exerciseMinutes'] ?? 0) as int,
+      readingMinutes: (json['readingMinutes'] ?? 0) as int,
+      hearingMinutes: (json['hearingMinutes'] ?? 0) as int,
       urgeIntensity: json['urgeIntensity'] as int,
       didFall: json['didFall'] as bool,
     );

--- a/lib/checkin/checkin_page.dart
+++ b/lib/checkin/checkin_page.dart
@@ -15,8 +15,9 @@ class _CheckinPageState extends State<CheckinPage> {
 
   TimeOfDay _wakeUpTime = const TimeOfDay(hour: 5, minute: 0);
   final _roundsController = TextEditingController();
-  bool _exercised = false;
-  bool _read = false;
+  final _exerciseController = TextEditingController();
+  final _readingController = TextEditingController();
+  final _hearingController = TextEditingController();
   double _urgeIntensity = 1;
   bool _didFall = false;
 
@@ -33,8 +34,9 @@ class _CheckinPageState extends State<CheckinPage> {
       setState(() {
         _wakeUpTime = data.wakeUpTime;
         _roundsController.text = data.rounds.toString();
-        _exercised = data.exercised;
-        _read = data.read;
+        _exerciseController.text = data.exerciseMinutes.toString();
+        _readingController.text = data.readingMinutes.toString();
+        _hearingController.text = data.hearingMinutes.toString();
         _urgeIntensity = data.urgeIntensity.toDouble();
         _didFall = data.didFall;
       });
@@ -45,8 +47,9 @@ class _CheckinPageState extends State<CheckinPage> {
     final data = CheckinData(
       wakeUpTime: _wakeUpTime,
       rounds: int.tryParse(_roundsController.text) ?? 0,
-      exercised: _exercised,
-      read: _read,
+      exerciseMinutes: int.tryParse(_exerciseController.text) ?? 0,
+      readingMinutes: int.tryParse(_readingController.text) ?? 0,
+      hearingMinutes: int.tryParse(_hearingController.text) ?? 0,
       urgeIntensity: _urgeIntensity.toInt(),
       didFall: _didFall,
     );
@@ -60,6 +63,9 @@ class _CheckinPageState extends State<CheckinPage> {
   @override
   void dispose() {
     _roundsController.dispose();
+    _exerciseController.dispose();
+    _readingController.dispose();
+    _hearingController.dispose();
     super.dispose();
   }
 
@@ -88,15 +94,23 @@ class _CheckinPageState extends State<CheckinPage> {
             decoration: const InputDecoration(labelText: 'Rounds'),
             keyboardType: TextInputType.number,
           ),
-          SwitchListTile(
-            title: const Text('Exercised'),
-            value: _exercised,
-            onChanged: (v) => setState(() => _exercised = v),
+          TextField(
+            controller: _exerciseController,
+            decoration:
+                const InputDecoration(labelText: 'Exercise minutes'),
+            keyboardType: TextInputType.number,
           ),
-          SwitchListTile(
-            title: const Text('Read scripture'),
-            value: _read,
-            onChanged: (v) => setState(() => _read = v),
+          TextField(
+            controller: _readingController,
+            decoration:
+                const InputDecoration(labelText: 'Reading minutes'),
+            keyboardType: TextInputType.number,
+          ),
+          TextField(
+            controller: _hearingController,
+            decoration:
+                const InputDecoration(labelText: 'Hearing minutes'),
+            keyboardType: TextInputType.number,
           ),
           ListTile(
             title: const Text('Urge intensity'),

--- a/lib/dashboard/dashboard_page.dart
+++ b/lib/dashboard/dashboard_page.dart
@@ -71,6 +71,39 @@ class _DashboardPageState extends State<DashboardPage> {
     return spots;
   }
 
+  List<FlSpot> get _exerciseSpots {
+    final dates = _data.keys.toList()..sort();
+    final List<FlSpot> spots = [];
+    for (var i = 0; i < dates.length; i++) {
+      final d = dates[i];
+      final info = _data[d]!;
+      spots.add(FlSpot(i.toDouble(), info.exerciseMinutes.toDouble()));
+    }
+    return spots;
+  }
+
+  List<FlSpot> get _readingSpots {
+    final dates = _data.keys.toList()..sort();
+    final List<FlSpot> spots = [];
+    for (var i = 0; i < dates.length; i++) {
+      final d = dates[i];
+      final info = _data[d]!;
+      spots.add(FlSpot(i.toDouble(), info.readingMinutes.toDouble()));
+    }
+    return spots;
+  }
+
+  List<FlSpot> get _hearingSpots {
+    final dates = _data.keys.toList()..sort();
+    final List<FlSpot> spots = [];
+    for (var i = 0; i < dates.length; i++) {
+      final d = dates[i];
+      final info = _data[d]!;
+      spots.add(FlSpot(i.toDouble(), info.hearingMinutes.toDouble()));
+    }
+    return spots;
+  }
+
   Future<void> _editQuote() async {
     final controller = TextEditingController(text: _quote);
     final result = await showDialog<String>(
@@ -154,6 +187,60 @@ class _DashboardPageState extends State<DashboardPage> {
           ),
           const SizedBox(height: 8),
           const Text('Urge intensity over time'),
+          const SizedBox(height: 16),
+          AspectRatio(
+            aspectRatio: 1.7,
+            child: LineChart(
+              LineChartData(
+                lineBarsData: [
+                  LineChartBarData(
+                    spots: _exerciseSpots,
+                    color: Theme.of(context).colorScheme.primary,
+                  ),
+                ],
+                titlesData: FlTitlesData(show: false),
+                gridData: FlGridData(show: false),
+              ),
+            ),
+          ),
+          const SizedBox(height: 8),
+          const Text('Exercise minutes over time'),
+          const SizedBox(height: 16),
+          AspectRatio(
+            aspectRatio: 1.7,
+            child: LineChart(
+              LineChartData(
+                lineBarsData: [
+                  LineChartBarData(
+                    spots: _readingSpots,
+                    color: Theme.of(context).colorScheme.secondary,
+                  ),
+                ],
+                titlesData: FlTitlesData(show: false),
+                gridData: FlGridData(show: false),
+              ),
+            ),
+          ),
+          const SizedBox(height: 8),
+          const Text('Reading minutes over time'),
+          const SizedBox(height: 16),
+          AspectRatio(
+            aspectRatio: 1.7,
+            child: LineChart(
+              LineChartData(
+                lineBarsData: [
+                  LineChartBarData(
+                    spots: _hearingSpots,
+                    color: Theme.of(context).colorScheme.tertiary,
+                  ),
+                ],
+                titlesData: FlTitlesData(show: false),
+                gridData: FlGridData(show: false),
+              ),
+            ),
+          ),
+          const SizedBox(height: 8),
+          const Text('Hearing minutes over time'),
         ],
       ),
     );


### PR DESCRIPTION
## Summary
- track exercise, reading, and hearing minutes in daily check-in
- display new duration metrics on the dashboard
- update features documentation

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877c4077aac832d9cc331b8225c67b7