### PR TITLE
Add selectable dates for check-ins

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -6,6 +6,7 @@ This document outlines planned capabilities for the **Nitya Dāsa** mobile appli
 
 - **Daily check-in** to track sadhana and personal goals including
   minutes spent exercising, reading, and hearing scripture
+  - Users can fill in entries for up to a week in the past
 - **Progress dashboard** with charts of japa counts, urge intensity,
   and time spent exercising, reading, and hearing
 - **Daily journal** for notes and reflections

--- a/test/checkin_page_test.dart
+++ b/test/checkin_page_test.dart
@@ -21,4 +21,32 @@ void main() {
 
     expect(find.text('Check-in saved'), findsOneWidget);
   });
+
+  testWidgets('User can select past date and save check-in', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: CheckinPage()));
+    await tester.pumpAndSettle();
+
+    final now = DateTime.now();
+    final past = now.subtract(const Duration(days: 2));
+
+    await tester.tap(find.text('Date'));
+    await tester.pumpAndSettle();
+
+    if (past.month != now.month) {
+      await tester.tap(find.byIcon(Icons.chevron_left));
+      await tester.pumpAndSettle();
+    }
+
+    await tester.tap(find.text('${past.day}'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Save'));
+    await tester.pumpAndSettle();
+
+    final prefs = await SharedPreferences.getInstance();
+    final key =
+        'checkin_${DateTime(past.year, past.month, past.day).toIso8601String()}';
+    expect(prefs.getString(key), isNotNull);
+    expect(find.text('Check-in saved'), findsOneWidget);
+  });
 }


### PR DESCRIPTION
## Summary
- let CheckinPage pick date within last 7 days
- load and save check-ins for the selected date
- test selecting a past date and saving
- document ability to fill in past week check-ins

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877c776bad4832d8e797d4a073d0957