### PR TITLE
Add journal deletion and replay button

### DIFF
--- a/lib/emergency/emergency_page.dart
+++ b/lib/emergency/emergency_page.dart
@@ -47,7 +47,10 @@ class _EmergencyPageState extends State<EmergencyPage> {
           Text(_vow, style: Theme.of(context).textTheme.titleMedium),
           const SizedBox(height: 16),
           ElevatedButton(
-            onPressed: () => widget._player.play(),
+            onPressed: () async {
+              await widget._player.seek(Duration.zero);
+              await widget._player.play();
+            },
             child: const Text('Play Mantra'),
           ),
         ],

--- a/lib/journal/journal_page.dart
+++ b/lib/journal/journal_page.dart
@@ -107,6 +107,18 @@ class _JournalPageState extends State<JournalPage> {
                         ),
                     ],
                   ),
+                  trailing: IconButton(
+                    icon: const Icon(Icons.delete),
+                    onPressed: () async {
+                      await _service.deleteEntry(e);
+                      await _load();
+                      if (mounted) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(content: Text('Entry deleted')),
+                        );
+                      }
+                    },
+                  ),
                 ),
               )),
         ],

--- a/lib/journal/journal_service.dart
+++ b/lib/journal/journal_service.dart
@@ -25,4 +25,15 @@ class JournalService {
     final raw = jsonEncode(entries.map((e) => e.toJson()).toList());
     await prefs.setString(_key, raw);
   }
+
+  Future<void> deleteEntry(JournalEntry entry) async {
+    final prefs = await SharedPreferences.getInstance();
+    final entries = await getEntries();
+    entries.removeWhere((e) =>
+        e.timestamp == entry.timestamp &&
+        e.helped == entry.helped &&
+        e.triggered == entry.triggered);
+    final raw = jsonEncode(entries.map((e) => e.toJson()).toList());
+    await prefs.setString(_key, raw);
+  }
 }

--- a/test/emergency_page_test.dart
+++ b/test/emergency_page_test.dart
@@ -6,7 +6,8 @@ import 'package:just_audio/just_audio.dart';
 import 'package:nitya_dasa/emergency/emergency_page.dart';
 
 class MockAudioPlayer extends AudioPlayer {
-  bool played = false;
+  int playCount = 0;
+  int seekCount = 0;
 
   @override
   Future<Duration?> setAsset(String path, {AudioLoadConfiguration? preload}) async {
@@ -15,7 +16,12 @@ class MockAudioPlayer extends AudioPlayer {
 
   @override
   Future<void> play() async {
-    played = true;
+    playCount++;
+  }
+
+  @override
+  Future<void> seek(Duration? position, {int? index}) async {
+    seekCount++;
   }
 
   @override
@@ -29,14 +35,20 @@ void main() {
     SharedPreferences.setMockInitialValues({});
   });
 
-  testWidgets('Emergency button starts playback', (tester) async {
+  testWidgets('Emergency button plays mantra each time tapped', (tester) async {
     final player = MockAudioPlayer();
     await tester.pumpWidget(MaterialApp(home: EmergencyPage(player: player)));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.widgetWithText(ElevatedButton, 'Play Mantra'));
+    final button = find.widgetWithText(ElevatedButton, 'Play Mantra');
+
+    await tester.tap(button);
     await tester.pump();
 
-    expect(player.played, isTrue);
+    await tester.tap(button);
+    await tester.pump();
+
+    expect(player.playCount, 2);
+    expect(player.seekCount, 2);
   });
 }

--- a/test/journal_page_test.dart
+++ b/test/journal_page_test.dart
@@ -30,4 +30,26 @@ void main() {
 
     expect(find.text('Journal entry saved'), findsOneWidget);
   });
+
+  testWidgets('Journal entry can be deleted', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: JournalPage()));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+        find.byWidgetPredicate((w) =>
+            w is TextField &&
+            w.decoration?.labelText == 'What helped you stay strong?'),
+        'Study');
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Save'));
+    await tester.pumpAndSettle();
+
+    final deleteButton = find.byIcon(Icons.delete);
+    expect(deleteButton, findsOneWidget);
+
+    await tester.tap(deleteButton);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Entry deleted'), findsOneWidget);
+    expect(find.byIcon(Icons.delete), findsNothing);
+  });
 }


### PR DESCRIPTION
## Summary
- allow deleting individual journal entries
- reset mantra playback so it can replay
- test deletion of journal entries
- test repeating mantra playback

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877c97e1ec0832dbcbc0a3b1af045ac