### PR TITLE
Add customizable emergency media

### DIFF
--- a/lib/dashboard/victory_quote_service.dart
+++ b/lib/dashboard/victory_quote_service.dart
@@ -22,4 +22,9 @@ class VictoryQuoteService {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_key, quote);
   }
+
+  Future<void> resetQuote() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_key);
+  }
 }

--- a/lib/emergency/emergency_media_service.dart
+++ b/lib/emergency/emergency_media_service.dart
@@ -1,0 +1,35 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class EmergencyMediaService {
+  static const _imageKey = 'emergency_image';
+  static const _audioKey = 'emergency_audio';
+
+  static const defaultImage = 'assets/images/emergency.jpg';
+  static const defaultAudio = 'assets/audio/mantra.mp3';
+
+  Future<String> getImagePath() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_imageKey) ?? defaultImage;
+  }
+
+  Future<String> getAudioPath() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_audioKey) ?? defaultAudio;
+  }
+
+  Future<void> setImagePath(String path) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_imageKey, path);
+  }
+
+  Future<void> setAudioPath(String path) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_audioKey, path);
+  }
+
+  Future<void> reset() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_imageKey);
+    await prefs.remove(_audioKey);
+  }
+}

--- a/lib/emergency/emergency_page.dart
+++ b/lib/emergency/emergency_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:just_audio/just_audio.dart';
 
+import 'emergency_media_service.dart';
 import 'vow_service.dart';
 
 class EmergencyPage extends StatefulWidget {
@@ -14,7 +15,10 @@ class EmergencyPage extends StatefulWidget {
 
 class _EmergencyPageState extends State<EmergencyPage> {
   final _vowService = VowService();
+  final _mediaService = EmergencyMediaService();
   String _vow = '';
+  String _imagePath = EmergencyMediaService.defaultImage;
+  String _audioPath = EmergencyMediaService.defaultAudio;
 
   @override
   void initState() {
@@ -24,9 +28,15 @@ class _EmergencyPageState extends State<EmergencyPage> {
 
   Future<void> _load() async {
     final vow = await _vowService.getVow();
+    final image = await _mediaService.getImagePath();
+    final audio = await _mediaService.getAudioPath();
     if (!mounted) return;
-    setState(() => _vow = vow);
-    await widget._player.setAsset('assets/audio/mantra.mp3');
+    setState(() {
+      _vow = vow;
+      _imagePath = image;
+      _audioPath = audio;
+    });
+    await widget._player.setAsset(audio);
   }
 
   @override
@@ -42,7 +52,7 @@ class _EmergencyPageState extends State<EmergencyPage> {
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [
-          Image.asset('assets/images/emergency.jpg', height: 200),
+          Image.asset(_imagePath, height: 200),
           const SizedBox(height: 16),
           Text(_vow, style: Theme.of(context).textTheme.titleMedium),
           const SizedBox(height: 16),

--- a/lib/settings/settings_page.dart
+++ b/lib/settings/settings_page.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 
 import '../notifications/notification_service.dart';
 import 'settings_service.dart';
+import '../emergency/emergency_media_service.dart';
+import '../dashboard/victory_quote_service.dart';
 
 class SettingsPage extends StatefulWidget {
   const SettingsPage({super.key});
@@ -12,8 +14,13 @@ class SettingsPage extends StatefulWidget {
 
 class _SettingsPageState extends State<SettingsPage> {
   final _service = SettingsService();
+  final _mediaService = EmergencyMediaService();
+  final _quoteService = VictoryQuoteService();
   TimeOfDay _morning = const TimeOfDay(hour: 7, minute: 0);
   TimeOfDay _evening = const TimeOfDay(hour: 19, minute: 0);
+  final _imageController = TextEditingController();
+  final _audioController = TextEditingController();
+  final _quoteController = TextEditingController();
 
   @override
   void initState() {
@@ -24,16 +31,25 @@ class _SettingsPageState extends State<SettingsPage> {
   Future<void> _load() async {
     final morning = await _service.getMorningTime();
     final evening = await _service.getEveningTime();
+    final image = await _mediaService.getImagePath();
+    final audio = await _mediaService.getAudioPath();
+    final quote = await _quoteService.getQuote();
     if (!mounted) return;
     setState(() {
       _morning = morning;
       _evening = evening;
+      _imageController.text = image;
+      _audioController.text = audio;
+      _quoteController.text = quote;
     });
   }
 
   Future<void> _save() async {
     await _service.setMorningTime(_morning);
     await _service.setEveningTime(_evening);
+    await _mediaService.setImagePath(_imageController.text);
+    await _mediaService.setAudioPath(_audioController.text);
+    await _quoteService.setQuote(_quoteController.text);
     await NotificationService.instance.scheduleDailyReminders(
       morning: _morning,
       evening: _evening,
@@ -42,6 +58,30 @@ class _SettingsPageState extends State<SettingsPage> {
       ScaffoldMessenger.of(context)
           .showSnackBar(const SnackBar(content: Text('Settings saved')));
     }
+  }
+
+  Future<void> _reset() async {
+    await _mediaService.reset();
+    await _quoteService.resetQuote();
+    final image = await _mediaService.getImagePath();
+    final audio = await _mediaService.getAudioPath();
+    final quote = await _quoteService.getQuote();
+    if (!mounted) return;
+    setState(() {
+      _imageController.text = image;
+      _audioController.text = audio;
+      _quoteController.text = quote;
+    });
+    ScaffoldMessenger.of(context)
+        .showSnackBar(const SnackBar(content: Text('Defaults restored')));
+  }
+
+  @override
+  void dispose() {
+    _imageController.dispose();
+    _audioController.dispose();
+    _quoteController.dispose();
+    super.dispose();
   }
 
   @override
@@ -77,10 +117,29 @@ class _SettingsPageState extends State<SettingsPage> {
               }
             },
           ),
+          TextField(
+            controller: _imageController,
+            decoration:
+                const InputDecoration(labelText: 'Emergency image path'),
+          ),
+          TextField(
+            controller: _audioController,
+            decoration:
+                const InputDecoration(labelText: 'Emergency mantra path'),
+          ),
+          TextField(
+            controller: _quoteController,
+            decoration: const InputDecoration(labelText: 'Victory quote'),
+          ),
           const SizedBox(height: 20),
           ElevatedButton(
             onPressed: _save,
             child: const Text('Save'),
+          ),
+          const SizedBox(height: 8),
+          ElevatedButton(
+            onPressed: _reset,
+            child: const Text('Reset Defaults'),
           ),
         ],
       ),

--- a/test/settings_page_test.dart
+++ b/test/settings_page_test.dart
@@ -30,4 +30,14 @@ void main() {
 
     expect(find.text('Settings saved'), findsOneWidget);
   });
+
+  testWidgets('Reset button shows snack bar', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: SettingsPage()));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Reset Defaults'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Defaults restored'), findsOneWidget);
+  });
 }


### PR DESCRIPTION
## Summary
- allow custom image and mantra paths on emergency page
- support resetting quote, image and mantra to defaults
- hook up new media settings in Settings page
- expose resetQuote in VictoryQuoteService
- test reset button snackbar

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877cc35868c832d9c1a9a52e2ede741