### PR TITLE
Add sleeping time tracking

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -4,11 +4,11 @@ This document outlines planned capabilities for the **Nitya Dāsa** mobile appli
 
 ## Main Functionality
 
-- **Daily check-in** to track sadhana and personal goals including
-  minutes spent exercising, reading, and hearing scripture
+ - **Daily check-in** to track sadhana and personal goals including
+   minutes spent exercising, reading, hearing scripture, and sleeping
   - Users can fill in entries for up to a week in the past
-- **Progress dashboard** with charts of japa counts, urge intensity,
-  and time spent exercising, reading, and hearing
+ - **Progress dashboard** with charts of japa counts, urge intensity,
+   and time spent exercising, reading, hearing, and sleeping
 - **Daily journal** for notes and reflections
 - **Emergency mode** for quick access to important practices and resources
 - **Notifications** and reminders to help stay consistent

--- a/lib/checkin/checkin_data.dart
+++ b/lib/checkin/checkin_data.dart
@@ -5,6 +5,7 @@ class CheckinData {
   final int exerciseMinutes;
   final int readingMinutes;
   final int hearingMinutes;
+  final int sleepMinutes;
   final int urgeIntensity;
   final bool didFall;
 
@@ -14,6 +15,7 @@ class CheckinData {
     required this.exerciseMinutes,
     required this.readingMinutes,
     required this.hearingMinutes,
+    required this.sleepMinutes,
     required this.urgeIntensity,
     required this.didFall,
   });
@@ -25,6 +27,7 @@ class CheckinData {
         'exerciseMinutes': exerciseMinutes,
         'readingMinutes': readingMinutes,
         'hearingMinutes': hearingMinutes,
+        'sleepMinutes': sleepMinutes,
         'urgeIntensity': urgeIntensity,
         'didFall': didFall,
       };
@@ -39,6 +42,7 @@ class CheckinData {
       exerciseMinutes: (json['exerciseMinutes'] ?? 0) as int,
       readingMinutes: (json['readingMinutes'] ?? 0) as int,
       hearingMinutes: (json['hearingMinutes'] ?? 0) as int,
+      sleepMinutes: (json['sleepMinutes'] ?? 0) as int,
       urgeIntensity: json['urgeIntensity'] as int,
       didFall: json['didFall'] as bool,
     );

--- a/lib/checkin/checkin_page.dart
+++ b/lib/checkin/checkin_page.dart
@@ -19,6 +19,7 @@ class _CheckinPageState extends State<CheckinPage> {
   final _exerciseController = TextEditingController();
   final _readingController = TextEditingController();
   final _hearingController = TextEditingController();
+  final _sleepController = TextEditingController();
   double _urgeIntensity = 1;
   bool _didFall = false;
 
@@ -39,6 +40,7 @@ class _CheckinPageState extends State<CheckinPage> {
         _exerciseController.text = data.exerciseMinutes.toString();
         _readingController.text = data.readingMinutes.toString();
         _hearingController.text = data.hearingMinutes.toString();
+        _sleepController.text = data.sleepMinutes.toString();
         _urgeIntensity = data.urgeIntensity.toDouble();
         _didFall = data.didFall;
       });
@@ -49,6 +51,7 @@ class _CheckinPageState extends State<CheckinPage> {
         _exerciseController.clear();
         _readingController.clear();
         _hearingController.clear();
+        _sleepController.clear();
         _urgeIntensity = 1;
         _didFall = false;
       });
@@ -62,6 +65,7 @@ class _CheckinPageState extends State<CheckinPage> {
       exerciseMinutes: int.tryParse(_exerciseController.text) ?? 0,
       readingMinutes: int.tryParse(_readingController.text) ?? 0,
       hearingMinutes: int.tryParse(_hearingController.text) ?? 0,
+      sleepMinutes: int.tryParse(_sleepController.text) ?? 0,
       urgeIntensity: _urgeIntensity.toInt(),
       didFall: _didFall,
     );
@@ -79,6 +83,7 @@ class _CheckinPageState extends State<CheckinPage> {
     _exerciseController.dispose();
     _readingController.dispose();
     _hearingController.dispose();
+    _sleepController.dispose();
     super.dispose();
   }
 
@@ -142,6 +147,12 @@ class _CheckinPageState extends State<CheckinPage> {
             controller: _hearingController,
             decoration:
                 const InputDecoration(labelText: 'Hearing minutes'),
+            keyboardType: TextInputType.number,
+          ),
+          TextField(
+            controller: _sleepController,
+            decoration:
+                const InputDecoration(labelText: 'Sleep minutes'),
             keyboardType: TextInputType.number,
           ),
           ListTile(

--- a/lib/dashboard/dashboard_page.dart
+++ b/lib/dashboard/dashboard_page.dart
@@ -119,6 +119,17 @@ class _DashboardPageState extends State<DashboardPage> {
     return spots;
   }
 
+  List<FlSpot> get _sleepSpots {
+    final dates = _sortedDates;
+    final List<FlSpot> spots = [];
+    for (var i = 0; i < dates.length; i++) {
+      final d = dates[i];
+      final info = _data[d]!;
+      spots.add(FlSpot(i.toDouble(), info.sleepMinutes.toDouble()));
+    }
+    return spots;
+  }
+
   Widget _bottomTitleWidgets(double value, TitleMeta meta) {
     final index = value.toInt();
     if (index < 0 || index >= _sortedDates.length) {
@@ -284,6 +295,24 @@ class _DashboardPageState extends State<DashboardPage> {
           ),
           const SizedBox(height: 8),
           const Text('Hearing minutes over time'),
+          const SizedBox(height: 16),
+          AspectRatio(
+            aspectRatio: 1.7,
+            child: LineChart(
+              LineChartData(
+                lineBarsData: [
+                  LineChartBarData(
+                    spots: _sleepSpots,
+                    color: Theme.of(context).colorScheme.primary,
+                  ),
+                ],
+                titlesData: _chartTitles(),
+                gridData: FlGridData(show: false),
+              ),
+            ),
+          ),
+          const SizedBox(height: 8),
+          const Text('Sleep minutes over time'),
           const SizedBox(height: 16),
           AspectRatio(
             aspectRatio: 1.7,

--- a/test/dashboard_page_test.dart
+++ b/test/dashboard_page_test.dart
@@ -18,6 +18,7 @@ void main() {
     expect(find.text('Dashboard'), findsOneWidget);
     expect(find.text('Current streak: 0 days'), findsOneWidget);
     expect(find.text('Total rounds over time'), findsOneWidget);
+    expect(find.text('Sleep minutes over time'), findsOneWidget);
     expect(find.text('Urge intensity over time'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- add sleep minutes to user check-in data
- show sleep minutes input on check-in page
- graph sleep minutes on the dashboard
- document sleep tracking capability
- update dashboard test

## Testing
- `flutter test test/dashboard_page_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877fab1da94832da3a3d30670392bf2